### PR TITLE
Support perl 5.8+

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -9,7 +9,9 @@ use ExtUtils::MakeMaker;
 WriteMakefile(
     NAME              => 'Try::Catch',
     VERSION_FROM      => 'lib/Try/Catch.pm', # finds $VERSION
-    PREREQ_PM         => {}, # none
+    PREREQ_PM         => {
+        perl => '5.8.0', # Haven't tested earlier versions
+    },
     ($] >= 5.005 ?     ## Add these new keywords supported since 5.005
       (ABSTRACT_FROM  => 'lib/Try/Catch.pm', # retrieve abstract from module
        AUTHOR         => 'Mamod A. Mehyar <mamod.mehyar@gmail.com>') : ()),

--- a/t/when.t
+++ b/t/when.t
@@ -2,7 +2,6 @@
 
 use strict;
 use warnings;
-use feature "switch";
 use Test::More;
 
 BEGIN {


### PR DESCRIPTION
There is nothing in the codebase that makes perl 5.8 support onerous. It should work on perl 5.6 too, but I can't readily test that (perl 5.8+ is the use-case I'm looking at).

This PR defines the minimum version of perl supported to be 5.8 in package metadata.

One test case had a `use feature ...` statement removed (aligning that test with the equivalent one from Try::Tiny).
