### PR TITLE
Protect $@ before calling finally block

### DIFF
--- a/lib/Try/Catch.pm
+++ b/lib/Try/Catch.pm
@@ -65,13 +65,21 @@ sub try(&;@) {
         };
 
         if ($ret){
-            $finally->($error) if $finally;
-            croak $@;
+            my $catch_error = $@;
+            if ($finally) {
+                $@ = $prev_error;
+                $finally->($error);
+            }
+            croak $catch_error;
         }
     }
 
+    if ($finally) {
+        $@ = $prev_error;
+        $finally->( $fail ? $error : () );
+    }
+
     $@ = $prev_error;
-    $finally->( $fail ? $error : () ) if $finally;
     return $wantarray ? @ret : $ret[0];
 }
 

--- a/t/finally.t
+++ b/t/finally.t
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-use Test::More tests => 21;
+use Test::More tests => 25;
 
 use Try::Catch;
 
@@ -105,6 +105,34 @@ finally {
 };
 is($_, "foo", "same afterwards");
 
+$@ = "previous error";
+try {
+} finally {
+  eval { "ok" };
+};
+is($@, "previous error", "finally does not modify previous \$@");
 
+$@ = "previous error";
+try {
+  die "foo";
+} catch {
+} finally {
+  eval { "ok" };
+};
+is($@, "previous error", "finally does not modify previous \$@");
+
+$@ = "previous error";
+try {
+  try {
+    die "foo";
+  } catch {
+    die "bar";
+  } finally {
+    eval { "ok" };
+  }
+} catch {
+  like($_[0], qr/^bar at/, "finally does not modify error from catch");
+  like($_, qr/^bar at/, "finally does not modify error from catch");
+};
 
 1;


### PR DESCRIPTION
Prevent finally block to modify previous error and error from catch.
This fixes bug: https://github.com/mamod/try-catch/issues/6