### PR TITLE
META does not point at GitHub issues

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -26,6 +26,7 @@ WriteMakefile(
                  url  => 'https://github.com/mamod/try-catch.git',
                  web  => 'https://github.com/mamod/try-catch',
              },
+             bugtracker => { web => 'https://github.com/mamod/try-catch/issues' },
          }})
          : ()
     ),       


### PR DESCRIPTION
… so s.c.o/MetaCPAN end up pointing to RT, which is presumably not where you want people to file issues. They also display the wrong number of issues.